### PR TITLE
Authorship Statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,292 @@
-/build
+##backup tex files
+*-backup.tex
+*useless.tex
+
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+*.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.glog
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# newpax
+*.newpax
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# TeXnicCenter
+*.tps
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz
+
+# xwatermark package
+*.xwm
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib

--- a/TexFiles/authorshipStatement.tex
+++ b/TexFiles/authorshipStatement.tex
@@ -1,0 +1,29 @@
+%%===============================================================%
+%%                     Authorship Statements                                                                           %
+%%===============================================================%
+%For each paper, include the contribution to the paper 
+% Include each paper as shown below. Abstracts are in a separate file.
+
+\chapter*{Authorship Statement}
+\label{chap:authorshipstatement}
+
+The following statement summarizes my personal contribution to the papers
+included in this thesis. Where relevant, co-authors have agreed with it. 
+Alternatively, this can appear as part of each paper. If you prefer the other option, 
+comment out the relevant line defining \texttt{authorshipStatementSection} in settings. 
+
+\begin{enumerate}[align=left,label={[\textbf{Paper \Roman*}]}]
+
+    \item 
+    Title of the first paper.
+    
+    This paper was co-authored with A, B, and C.
+    The research idea came from .... 
+    The formalization, encoding, implementation, and testing were done by me.
+    The writing of the paper was done jointly with me contributing most of the material. 
+    \item
+    Title of the second paper.
+        
+     My contribution to this paper. 
+\end{enumerate}
+

--- a/TexFiles/settings.tex
+++ b/TexFiles/settings.tex
@@ -2,9 +2,15 @@
 %%                               Settings                                  %
 %%=========================================================================%
 
-%Comment out or remove if it's a Licentiate thesis!
+% Comment out or remove if it's a Licentiate thesis!
 \def\phdThesis{1}
+
+% Comment out or remove if the thesis is for a DEng rather than DPhil
 \def\philosophyThesis{1}
+
+% Comment out or remove if you prefer to write authorship statement along
+% with the descriptions of the papers. 
+\def\authorshipStatementSection{1}
 
 % Important commands for this thesis!
 \newcommand{\currentyear}{2018}
@@ -61,7 +67,6 @@ Technical Report No. \techReportNumber \\
 \vspace{1.5cm}
 }
 \fi
-
 
 
 

--- a/TexFiles/summary.tex
+++ b/TexFiles/summary.tex
@@ -45,7 +45,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 
 
-\subsubsection*{Contribution}
+\subsubsection*{Scientific Contribution}
 
 What does the paper do to try to solve the problem?
 
@@ -62,6 +62,18 @@ How is it implemented?
 
 Consequat nisl vel pretium lectus quam id. Phasellus egestas tellus rutrum tellus. Id neque aliquam vestibulum morbi blandit cursus risus at ultrices. Est ultricies integer quis auctor elit sed vulputate. Eu consequat ac felis donec et odio pellentesque diam volutpat. Urna id volutpat lacus laoreet non curabitur gravida arcu ac. Scelerisque purus semper eget duis at tellus. Porttitor leo a diam sollicitudin tempor id eu nisl nunc. Mauris nunc congue nisi vitae suscipit tellus mauris. Leo duis ut diam quam nulla porttitor massa id neque. In hendrerit gravida rutrum quisque non. Ornare lectus sit amet est.
 
+
+\ifx\authorshipStatementSection\undefined
+\subsubsection*{Authorship Statement}
+
+
+What are the contributions of each of the authors to the paper? Your co-authors should agree to this. 
+
+\vskip 1cm
+
+Molestie a iaculis at erat. In vitae turpis massa sed elementum tempus. Tincidunt id aliquet risus feugiat in ante metus. Nunc sed blandit libero volutpat. Pharetra diam sit amet nisl. Eu facilisis sed odio morbi quis commodo odio. Porta lorem mollis aliquam ut porttitor. Metus vulputate eu scelerisque felis imperdiet. Volutpat sed cras ornare arcu dui vivamus arcu felis bibendum. Ultrices mi tempus imperdiet nulla. Tristique sollicitudin nibh sit amet commodo nulla facilisi nullam. Tortor vitae purus faucibus ornare suspendisse sed. Quisque id diam vel quam elementum pulvinar etiam non. Platea dictumst vestibulum rhoncus est pellentesque.
+
+\fi
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \clearpage
@@ -81,7 +93,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 
 
-\subsubsection*{Contribution}
+\subsubsection*{Scientific Contribution}
 
 What does the paper do to try to solve the problem?
 
@@ -98,6 +110,18 @@ How is it implemented?
 
 Consequat nisl vel pretium lectus quam id. Phasellus egestas tellus rutrum tellus. Id neque aliquam vestibulum morbi blandit cursus risus at ultrices. Est ultricies integer quis auctor elit sed vulputate. Eu consequat ac felis donec et odio pellentesque diam volutpat. Urna id volutpat lacus laoreet non curabitur gravida arcu ac. Scelerisque purus semper eget duis at tellus. Porttitor leo a diam sollicitudin tempor id eu nisl nunc. Mauris nunc congue nisi vitae suscipit tellus mauris. Leo duis ut diam quam nulla porttitor massa id neque. In hendrerit gravida rutrum quisque non. Ornare lectus sit amet est.
 
+
+\ifx\authorshipStatementSection\undefined
+\subsubsection*{Authorship Statement}
+
+
+What are the contributions of each of the authors to the paper? Your co-authors should agree to this. 
+
+\vskip 1cm
+
+Molestie a iaculis at erat. In vitae turpis massa sed elementum tempus. Tincidunt id aliquet risus feugiat in ante metus. Nunc sed blandit libero volutpat. Pharetra diam sit amet nisl. Eu facilisis sed odio morbi quis commodo odio. Porta lorem mollis aliquam ut porttitor. Metus vulputate eu scelerisque felis imperdiet. Volutpat sed cras ornare arcu dui vivamus arcu felis bibendum. Ultrices mi tempus imperdiet nulla. Tristique sollicitudin nibh sit amet commodo nulla facilisi nullam. Tortor vitae purus faucibus ornare suspendisse sed. Quisque id diam vel quam elementum pulvinar etiam non. Platea dictumst vestibulum rhoncus est pellentesque.
+
+\fi
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/main.tex
+++ b/main.tex
@@ -35,6 +35,17 @@
 \thispagestyle{plain}
 \include{TexFiles/publicationsList}
 
+\ifx\authorshipStatementSection\undefined
+\else
+%Authorship statement
+\thispagestyle{empty} % To avoid page numbers in blank pages
+\cleardoublepage \addcontentsline{toc}{chapter}{Authorship Statement}
+\thispagestyle{plain}
+\include{TexFiles/authorshipStatement}
+\fi
+
+
+
 %Acknowledgment
 \thispagestyle{empty} % To avoid page numbers in blank pages
 \cleardoublepage \addcontentsline{toc}{chapter}{Acknowledgment}
@@ -95,7 +106,6 @@
 \cleardoublepage
 
 \include{TexFiles/appendedPapers}
-
 
 %
 %================================================================%

--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,7 @@
 \documentclass[10pt,onecolumn,openright]{book}
 
 % Configure title, author, etc of the thesis in TexFiles/settings.tex
-
+% Creating a branch
 %================================================================%
 %  All packages and new commands are treated in an own document  %
 %================================================================%


### PR DESCRIPTION
Added templates for inclusion of authorship statements regarding papers.
The main approach adds a section after the list of included papers where it is suggested to include the contributions to each paper.
There is an alternative to include that in the summary of each paper. 
There's a control added to the settings to control which option to use.

Finally, took the opportunity to add a .gitignore so that I'm not bothered by all the latex junk. 